### PR TITLE
Filter out React Query cache from mmkv

### DIFF
--- a/src/react-query-external-sync/hooks/useDynamicMmkvQueries.ts
+++ b/src/react-query-external-sync/hooks/useDynamicMmkvQueries.ts
@@ -47,7 +47,10 @@ export interface MmkvQueryResult {
 export function useDynamicMmkvQueries({ queryClient, storage }: UseDynamicMmkvQueriesOptions): MmkvQueryResult[] {
   // Get all MMKV keys
   const mmkvKeys = useMemo(() => {
-    return storage.getAllKeys();
+    const keys = storage.getAllKeys();
+    // Filter out React Query cache and other noisy keys
+    const filteredKeys = keys.filter((key) => !key.includes('REACT_QUERY_OFFLINE_CACHE'));
+    return filteredKeys;
   }, [storage]);
 
   // Helper function to get a single MMKV value


### PR DESCRIPTION
Just like with AsyncStorage, MMKV can be used to persist the React Query cache. To reduce noise in the debugger view, this PR filters out the React Query cache key from being displayed.