### PR TITLE
feat(platformUtils): add a prop to expecify if it`s a real device

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The `useSyncQueriesExternal` hook accepts the following options:
 | `deviceId`          | string       | Yes      | Unique identifier for your device                                       |
 | `extraDeviceInfo`   | object       | No       | Additional device metadata to display in DevTools                       |
 | `enableLogs`        | boolean      | No       | Enable console logging for debugging (default: false)                   |
+| `isDevice`          | boolean      | No       | Set to true if this is a device (default: false)                        |
 | `envVariables`      | object       | No       | Environment variables to sync with DevTools                             |
 | `mmkvStorage`       | MmkvStorage  | No       | MMKV storage instance for real-time monitoring                          |
 | `asyncStorage`      | AsyncStorage | No       | AsyncStorage instance for polling-based monitoring                      |

--- a/src/react-query-external-sync/platformUtils.ts
+++ b/src/react-query-external-sync/platformUtils.ts
@@ -45,13 +45,15 @@ export const isReactNative = (): boolean => {
  */
 export const getPlatformSpecificURL = (
   baseUrl: string,
-  platform: PlatformOS
+  platform: PlatformOS,
+  isDevice: boolean
 ): string => {
   try {
     const url = new URL(baseUrl);
 
     // For Android emulator, replace hostname with 10.0.2.2
     if (
+      !isDevice &&
       platform === "android" &&
       (url.hostname === "localhost" || url.hostname === "127.0.0.1")
     ) {

--- a/src/react-query-external-sync/useMySocket.ts
+++ b/src/react-query-external-sync/useMySocket.ts
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from "react";
-import { io as socketIO, Socket } from "socket.io-client";
+import { useEffect, useRef, useState } from 'react';
+import { io as socketIO, Socket } from 'socket.io-client';
 
-import { log } from "./utils/logger";
-import { getPlatformSpecificURL, PlatformOS } from "./platformUtils";
+import { log } from './utils/logger';
+import { getPlatformSpecificURL, PlatformOS } from './platformUtils';
 
 interface Props {
   deviceName: string; // Unique name to identify the device
@@ -16,12 +16,12 @@ interface Props {
    * @default false
    */
   enableLogs?: boolean;
-  /**
+   /**
    * Whether the app is running on a physical device or an emulator/simulator
    * This can affect how the socket URL is constructed, especially on Android
    * @default false
    */
-  isDevice?: boolean; // Whether the app is running on a physical device
+  isDevice?: boolean // Whether the app is running on a physical device
 }
 
 /**
@@ -29,7 +29,7 @@ interface Props {
  * This way multiple components can share the same socket connection
  */
 let globalSocketInstance: Socket | null = null;
-let currentSocketURL = "";
+let currentSocketURL = '';
 
 /**
  * Hook that handles socket connection for device-dashboard communication
@@ -49,7 +49,7 @@ export function useMySocket({
   envVariables,
   platform,
   enableLogs = false,
-  isDevice = false,
+  isDevice = false
 }: Props) {
   const socketRef = useRef<Socket | null>(null);
   const [socket, setSocket] = useState<Socket | null>(null);
@@ -85,15 +85,11 @@ export function useMySocket({
     };
 
     const onConnectError = (error: Error) => {
-      log(
-        `${logPrefix} Socket connection error: ${error.message}`,
-        enableLogs,
-        "error"
-      );
+      log(`${logPrefix} Socket connection error: ${error.message}`, enableLogs, 'error');
     };
 
     const onConnectTimeout = () => {
-      log(`${logPrefix} Socket connection timeout`, enableLogs, "error");
+      log(`${logPrefix} Socket connection timeout`, enableLogs, 'error');
     };
 
     // Get the platform-specific URL
@@ -113,21 +109,18 @@ export function useMySocket({
             envVariables: JSON.stringify(envVariables),
           },
           reconnection: false,
-          transports: ["websocket"], // Prefer websocket transport for React Native
+          transports: ['websocket'], // Prefer websocket transport for React Native
         });
       } else {
-        log(
-          `${logPrefix} Reusing existing socket instance to ${platformUrl}`,
-          enableLogs
-        );
+        log(`${logPrefix} Reusing existing socket instance to ${platformUrl}`, enableLogs);
       }
 
       socketRef.current = globalSocketInstance;
       setSocket(socketRef.current);
 
       // Setup error event listener
-      socketRef.current.on("connect_error", onConnectError);
-      socketRef.current.on("connect_timeout", onConnectTimeout);
+      socketRef.current.on('connect_error', onConnectError);
+      socketRef.current.on('connect_timeout', onConnectTimeout);
 
       // Check initial connection state
       if (socketRef.current.connected) {
@@ -136,27 +129,23 @@ export function useMySocket({
       }
 
       // Set up event handlers
-      socketRef.current.on("connect", onConnect);
-      socketRef.current.on("disconnect", onDisconnect);
+      socketRef.current.on('connect', onConnect);
+      socketRef.current.on('disconnect', onDisconnect);
 
       // Clean up event listeners on unmount but don't disconnect
       return () => {
         if (socketRef.current) {
           log(`${logPrefix} Cleaning up socket event listeners`, enableLogs);
-          socketRef.current.off("connect", onConnect);
-          socketRef.current.off("disconnect", onDisconnect);
-          socketRef.current.off("connect_error", onConnectError);
-          socketRef.current.off("connect_timeout", onConnectTimeout);
+          socketRef.current.off('connect', onConnect);
+          socketRef.current.off('disconnect', onDisconnect);
+          socketRef.current.off('connect_error', onConnectError);
+          socketRef.current.off('connect_timeout', onConnectTimeout);
           // Don't disconnect socket on component unmount
           // We want it to remain connected for the app's lifetime
         }
       };
     } catch (error) {
-      log(
-        `${logPrefix} Failed to initialize socket: ${error}`,
-        enableLogs,
-        "error"
-      );
+      log(`${logPrefix} Failed to initialize socket: ${error}`, enableLogs, 'error');
     }
     // ## DON'T ADD ANYTHING ELSE TO THE DEPENDENCY ARRAY ###
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -164,11 +153,7 @@ export function useMySocket({
 
   // Update the socket query parameters when deviceName changes
   useEffect(() => {
-    if (
-      socketRef.current &&
-      socketRef.current.io.opts.query &&
-      persistentDeviceId
-    ) {
+    if (socketRef.current && socketRef.current.io.opts.query && persistentDeviceId) {
       socketRef.current.io.opts.query = {
         ...socketRef.current.io.opts.query,
         deviceName,
@@ -184,25 +169,15 @@ export function useMySocket({
     const platformUrl = getPlatformSpecificURL(socketURL, platform, isDevice);
 
     // Compare with last known URL to avoid direct property access
-    if (
-      socketRef.current &&
-      currentSocketURL !== platformUrl &&
-      persistentDeviceId
-    ) {
-      log(
-        `${logPrefix} Socket URL changed from ${currentSocketURL} to ${platformUrl}`,
-        enableLogs
-      );
+    if (socketRef.current && currentSocketURL !== platformUrl && persistentDeviceId) {
+      log(`${logPrefix} Socket URL changed from ${currentSocketURL} to ${platformUrl}`, enableLogs);
 
       try {
         // Only recreate socket if URL actually changed
         socketRef.current.disconnect();
         currentSocketURL = platformUrl;
 
-        log(
-          `${logPrefix} Creating new socket connection to ${platformUrl}`,
-          enableLogs
-        );
+        log(`${logPrefix} Creating new socket connection to ${platformUrl}`, enableLogs);
         globalSocketInstance = socketIO(platformUrl, {
           autoConnect: true,
           query: {
@@ -213,29 +188,16 @@ export function useMySocket({
             envVariables: JSON.stringify(envVariables),
           },
           reconnection: false,
-          transports: ["websocket"], // Prefer websocket transport for React Native
+          transports: ['websocket'], // Prefer websocket transport for React Native
         });
 
         socketRef.current = globalSocketInstance;
         setSocket(socketRef.current);
       } catch (error) {
-        log(
-          `${logPrefix} Failed to update socket connection: ${error}`,
-          enableLogs,
-          "error"
-        );
+        log(`${logPrefix} Failed to update socket connection: ${error}`, enableLogs, 'error');
       }
     }
-  }, [
-    socketURL,
-    deviceName,
-    logPrefix,
-    persistentDeviceId,
-    platform,
-    enableLogs,
-    extraDeviceInfo,
-    envVariables,
-  ]);
+  }, [socketURL, deviceName, logPrefix, persistentDeviceId, platform, enableLogs, extraDeviceInfo, envVariables]);
 
   /**
    * Manually connect to the socket server

--- a/src/react-query-external-sync/useSyncQueriesExternal.ts
+++ b/src/react-query-external-sync/useSyncQueriesExternal.ts
@@ -146,6 +146,12 @@ interface useSyncQueriesExternalProps {
    * @default false
    */
   enableLogs?: boolean;
+  /**
+   * Whether the app is running on a physical device or an emulator/simulator
+   * This can affect how the socket URL is constructed, especially on Android
+   * @default false
+   */
+  isDevice?: boolean; // Whether the app is running on a physical device
 
   /**
    * Storage instances for different storage types
@@ -312,6 +318,7 @@ export function useSyncQueriesExternal({
   platform,
   deviceId,
   enableLogs = false,
+  isDevice = false,
   storage,
   mmkvStorage,
   asyncStorage,
@@ -439,6 +446,7 @@ export function useSyncQueriesExternal({
     envVariables: mergedEnvVariables,
     platform,
     enableLogs,
+    isDevice,
   });
 
   useEffect(() => {


### PR DESCRIPTION
In real Android devices utilizing react native cli and running the application though adb, the function getPlatformSpecificURL will consider the app is running in a emulator and replace localhost with 10.0.2.2 this stops the app from forming a websocket connection.

A prop was added to enable specifying if a app is running on a emulator or real device:
```ts
/**
 * Get platform-specific URL for socket connection
 * On Android emulator, we need to replace localhost with 10.0.2.2
 */
export const getPlatformSpecificURL = (
  baseUrl: string,
  platform: PlatformOS,
  isDevice: boolean
): string => {
  try {
    const url = new URL(baseUrl);

    // For Android emulator, replace hostname with 10.0.2.2
    if (
      !isDevice &&
      platform === "android" &&
      (url.hostname === "localhost" || url.hostname === "127.0.0.1")
    ) {
      url.hostname = "10.0.2.2";
      return url.toString();
    }

    // For other platforms, use as provided
    return baseUrl;
  } catch (e) {
    console.warn("Error getting platform-specific URL:", e);
    return baseUrl;
  }
};
```

It can be used with ExpoDevice like so:

```ts
	import * as ExpoDevice from "expo-device"


	useSyncQueriesExternal({
		queryClient,
		isDevice: ExpoDevice.isDevice,
		socketURL: "http://localhost:42831", // Default port for React Native DevTools
		deviceName: Platform?.OS || "web", // Platform detection
		platform: Platform?.OS || "web", // Use appropriate platform identifier
		deviceId: Platform?.OS || "web", // Use a PERSISTENT identifier (see note below)
		extraDeviceInfo: {
			// Optional additional info about your device
			appVersion: "1.0.0"
			// Add any relevant platform info
		},
		enableLogs: true,
		envVariables: {
			NODE_ENV: process.env.NODE_ENV
			// Add any private environment variables you want to monitor
			// Public environment variables are automatically loaded
		}
	})
```

